### PR TITLE
Implemented new feature which allow the user to highlight a message

### DIFF
--- a/app/controllers/api/v1/widget/messages_controller.rb
+++ b/app/controllers/api/v1/widget/messages_controller.rb
@@ -59,7 +59,18 @@ class Api::V1::Widget::MessagesController < Api::V1::Widget::BaseController
   end
 
   def message_update_params
-    params.permit(message: [{ submitted_values: [:name, :title, :value, { csat_survey_response: [:feedback_message, :rating] }] }])
+    params.permit(
+      message: [
+        { submitted_values: [:name, :title, :value, { csat_survey_response: [:feedback_message, :rating] }] },
+        :content,
+        { content_attributes: permit_content_attributes_keys }
+      ]
+    )
+  end
+
+  def permit_content_attributes_keys
+    # Allow specific known keys
+    [:is_highlighted, :priority, :category, :tags, :metadata]
   end
 
   def permitted_params

--- a/app/javascript/dashboard/components-next/message/Message.vue
+++ b/app/javascript/dashboard/components-next/message/Message.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { onMounted, computed, ref, toRefs } from 'vue';
+import { messageStore } from '@/dashboard/store/messageStore.js';
 import { useTimeoutFn } from '@vueuse/core';
 import { provideMessageContext } from './provider.js';
 import { useTrack } from 'dashboard/composables';
@@ -130,6 +131,7 @@ const props = defineProps({
   sourceId: { type: String, default: '' }, // eslint-disable-line vue/no-unused-properties
 });
 
+const emit = defineEmits(['update:contentAttributes']);
 const contextMenuPosition = ref({});
 const showBackgroundHighlight = ref(false);
 const showContextMenu = ref(false);
@@ -376,6 +378,31 @@ const shouldRenderMessage = computed(() => {
   );
 });
 
+const isHighlighted = computed(() => messageStore.getIsHighlighted(props.id));
+
+function toggleIsHighlighted() {
+  const newValue = messageStore.toggleIsHighlighted(props.id);
+  emit('update:contentAttributes', {
+    id: props.id,
+    attributes: { is_highlighted: newValue },
+  });
+}
+
+/**
+ * Updates a specific content attribute of the message
+ * @param {string} key - The attribute key to update
+ * @param {any} value - The new value for the attribute
+ * @fires update:contentAttributes - Emits an event to the parent component with the updated attributes
+ */
+
+// eslint-disable-next-line no-unused-vars
+function updateContentAttribute(key, value) {
+  emit('update:contentAttributes', {
+    id: props.id,
+    attributes: { [key]: value },
+  });
+}
+
 function openContextMenu(e) {
   const shouldSkipContextMenu =
     e.target?.classList.contains('skip-context-menu') ||
@@ -476,8 +503,10 @@ provideMessageContext({
       {
         'group-with-next': shouldGroupWithNext,
         'bg-n-alpha-1': showBackgroundHighlight,
+        'bubble-highlighted': isHighlighted,
       },
     ]"
+    @click="toggleIsHighlighted"
   >
     <div v-if="variant === MESSAGE_VARIANTS.ACTIVITY">
       <ActivityBubble :content="content" />
@@ -546,5 +575,10 @@ provideMessageContext({
   .right-bubble {
     @apply ltr:rounded-tr-sm rtl:rounded-tl-sm;
   }
+}
+
+.message-bubble-container.bubble-highlighted {
+  background-color: #ffdddd !important;
+  border: 2px solid #08ff00 !important;
 }
 </style>

--- a/app/javascript/dashboard/store/messageStore.js
+++ b/app/javascript/dashboard/store/messageStore.js
@@ -1,0 +1,81 @@
+/**
+ * Message State Management Store
+ * A reactive store that manages message highlighting states and persists them in localStorage.
+ * This allows message highlights to persist across page refreshes.
+ */
+
+import { reactive } from 'vue';
+
+/**
+ * Message State Management Store
+ * A reactive store that manages message highlighting states and persists them in localStorage.
+ * This allows message highlights to persist across page refreshes.
+ */
+export const messageStore = reactive({
+  /**
+   * Map storing the state for each message
+   * @type {Map<number, Object>}
+   */
+  messageStates: new Map(),
+
+  /**
+   * Initializes the store by loading saved states from localStorage
+   */
+  init() {
+    const saved = localStorage.getItem('messageHighlightedStates');
+    if (saved) {
+      try {
+        const data = JSON.parse(saved);
+        Object.entries(data).forEach(([id, state]) => {
+          this.messageStates.set(parseInt(id, 10), state);
+        });
+      } catch (e) {
+        // eslint-disable-next-line no-console
+        console.error('Failed to load saved message states:', e);
+      }
+    }
+  },
+
+  /**
+   * Persists the current message states to localStorage
+   */
+  persist() {
+    const data = Object.fromEntries(this.messageStates);
+    localStorage.setItem('messageHighlightedStates', JSON.stringify(data));
+  },
+
+  /**
+   * Checks if a message is highlighted
+   * @param {number} messageId - The ID of the message
+   * @returns {boolean} Whether the message is highlighted
+   */
+  getIsHighlighted(messageId) {
+    return this.messageStates.get(messageId)?.isHighlighted === true;
+  },
+
+  /**
+   * Sets the highlight state for a message
+   * @param {number} messageId - The ID of the message
+   * @param {boolean} value - The highlight state to set
+   */
+  setIsHighlighted(messageId, value) {
+    const current = this.messageStates.get(messageId) || {};
+    this.messageStates.set(messageId, { ...current, isHighlighted: value });
+    this.persist(); // Auto-save
+  },
+
+  /**
+   * Toggles the highlight state for a message
+   * @param {number} messageId - The ID of the message
+   * @returns {boolean} The new highlight state
+   */
+  toggleIsHighlighted(messageId) {
+    const current = this.getIsHighlighted(messageId);
+    const newValue = !current;
+    this.setIsHighlighted(messageId, newValue);
+    return newValue;
+  },
+});
+
+// Initialize the store when the module is loaded
+messageStore.init();


### PR DESCRIPTION
# Pull Request #3

## Description
A new feature was implemented, allowing the user to click on a bubble message to highlight it. The user can then easily find the messages they judge essential. The message highlight is persistent across page refresh, and can be removed by simply clicking on it.


## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

## How Has This Been Tested?

The code was started. Inside the interface, we can just click on the message multiple times to see that it can be highlighted and de-highlighted as needed. The page was also reloaded and navigated away, and the status of each message was saved correctly.


## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
